### PR TITLE
Prevent unnecessary queryString concatenation on retry URLs

### DIFF
--- a/angular-cache-buster.js
+++ b/angular-cache-buster.js
@@ -42,6 +42,7 @@ angular.module('ngCacheBuster', [])
 		    //Bust if the URL was on blacklist or not on whitelist
 		    if (busted) {
 			var d = new Date();
+			config.url = config.url.replace(/[?|&]cacheBuster=\d+/,'');
 			//Some url's allready have '?' attached
 			config.url+=config.url.indexOf('?') === -1 ? '?' : '&'
 			config.url += 'cacheBuster=' + d.getTime();


### PR DESCRIPTION
Encountered this while utilizing a interceptor that attempts retries on failed requests. Without this change, the querystring keeps getting appended with additional cacheBuster=1234567 etc.
