### PR TITLE
Fixed comment describing whitelist and blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In your app module definition, add `ngCacheBuster` as a dependency
 # configure
 
 AngularCacheBuster adds a cache buster to any $http requests (and hence to $resource requests).
-Since you probably want to maintain browser caching for your views, partials or other routes, you can supply a list of regexes that will be matched against all URL's. By default the supplied matchlist is a whitelist (i.e. busting everything not matching an entry in the list) but you can also set it to be a blacklist, (i.e. busting everything except the matching entries)
+Since you probably want to maintain browser caching for your views, partials or other routes, you can supply a list of regexes that will be matched against all URL's. By default the supplied matchlist is a whitelist (i.e. busting everything not matching an entry in the list) but you can also set it to be a blacklist, (i.e. busting everything matching entries)
 
 For instance, if you want to bust everything except views in a 'partials' folder and images in a 'images' folder , you can configure AngularCacheBuster this way:
 


### PR DESCRIPTION
Comment describing blacklisting and whitelisting was incorrect. 

For whitelist, it was "busting everything not matching entry" and blacklist "busting everything except entries"